### PR TITLE
Fix Math import in UpdateChecker

### DIFF
--- a/src/main/java/de/pixelmindmc/pixelchat/utils/UpdateChecker.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/utils/UpdateChecker.java
@@ -10,7 +10,6 @@ import com.google.gson.JsonParser;
 import de.pixelmindmc.pixelchat.PixelChat;
 import de.pixelmindmc.pixelchat.constants.LangConstants;
 import org.jetbrains.annotations.NotNull;
-import org.joml.Math;
 
 import java.io.BufferedReader;
 import java.io.IOException;


### PR DESCRIPTION
## Summary
- use `java.lang.Math` in `UpdateChecker`

## Testing
- `./gradlew clean compileJava --no-daemon` *(fails: Could not resolve org.spigotmc:spigot-api due to 403 Forbidden)*

