### PR TITLE
Add racism autoban and server ad filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ players.
   and use it in their preferred language.
 - **Compatibility with other Chat Plugins**: Designed to work seamlessly alongside other chat plugins, our solution
   integrates effortlessly into your existing setup.
+- **Discord Integration**: Optionally forward blocked messages to a Discord channel via webhook for quick moderator insight.
+- **Advertising Filter**: Block messages advertising other servers while allowing your whitelisted domains.
 
 ## Installation
 
@@ -44,6 +46,13 @@ players.
 - Always **create or update** your configuration files when updating the plugin to prevent any issues.
 - By default, the plugin collects **anonymous statistics**. You can view these
   on [bStats](https://www.bstats.org/plugin/bukkit/PixelChat%20Guardian/23371).
+- If enabled, blocked chat messages are forwarded to the configured Discord channel. Set `discord-integration.enabled` and `discord-integration.webhook-url` in `config.yml`.
+
+## Privacy & Data Usage
+
+PixelChat Guardian transmits player chat messages to the configured AI endpoint (Groq by default) for moderation purposes. The plugin does not store these messages beyond processing. Server administrators can disable AI moderation by setting the `modules.chatguard` option to `false` in `config.yml`.
+
+Anonymous usage statistics are submitted to [bStats](https://www.bstats.org) when `enable-metrics` is enabled. You may disable this telemetry by setting the option to `false`.
 
 ## Need Help or Have Suggestions?
 

--- a/src/main/java/de/pixelmindmc/pixelchat/PixelChat.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/PixelChat.java
@@ -70,6 +70,13 @@ public final class PixelChat extends JavaPlugin {
         registerCommands();
         registerTabCompleter(new TabCompleter());
 
+        initializeMetrics();
+        try {
+            checkForUpdates();
+        } catch (Exception e) {
+            getLoggingHelper().warning("Update check failed: " + e.getMessage());
+        }
+
     }
 
     /**
@@ -90,6 +97,8 @@ public final class PixelChat extends JavaPlugin {
         configHelperLangSimplifiedChinese = new ConfigHelper(this, "locale/locale_zh-cn.yml");
         configHelperLangTraditionalChinese = new ConfigHelper(this, "locale/locale_zh-tw.yml");
 
+        ensureConfigEntries();
+
         // Check config versions
         String version = getDescription().getVersion();
         if (!version.equalsIgnoreCase(getConfigHelper().getString(ConfigConstants.CONFIG_VERSION)))
@@ -104,6 +113,33 @@ public final class PixelChat extends JavaPlugin {
 
         // Reset the strike count of every player if enabled
         if (getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_CLEAR_STRIKES_ON_SERVER_RESTART)) resetPlayerStrikesOnServerStart();
+    }
+
+    /**
+     * Ensures that additional settings exist in the config.
+     */
+    private void ensureConfigEntries() {
+        boolean changed = false;
+        if (!configHelper.contains(ConfigConstants.DISCORD_INTEGRATION_ENABLED)) {
+            configHelper.set(ConfigConstants.DISCORD_INTEGRATION_ENABLED, false);
+            changed = true;
+        }
+        if (!configHelper.contains(ConfigConstants.DISCORD_INTEGRATION_WEBHOOK_URL)) {
+            configHelper.set(ConfigConstants.DISCORD_INTEGRATION_WEBHOOK_URL, "WEBHOOK_URL");
+            changed = true;
+        }
+        if (!configHelper.contains(ConfigConstants.CHATGUARD_BLOCK_EXTERNAL_SERVER_ADS)) {
+            configHelper.set(ConfigConstants.CHATGUARD_BLOCK_EXTERNAL_SERVER_ADS, true);
+            changed = true;
+        }
+        if (!configHelper.contains(ConfigConstants.CHATGUARD_ALLOWED_SERVER_DOMAINS)) {
+            java.util.List<String> defaults = java.util.List.of("leki-world.de");
+            configHelper.set(ConfigConstants.CHATGUARD_ALLOWED_SERVER_DOMAINS, defaults);
+            changed = true;
+        }
+        if (changed) {
+            getLoggingHelper().info("Added missing config defaults to config.yml");
+        }
     }
 
     /**

--- a/src/main/java/de/pixelmindmc/pixelchat/constants/ConfigConstants.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/constants/ConfigConstants.java
@@ -16,6 +16,12 @@ public class ConfigConstants {
     public static final String CHECK_FOR_UPDATES = "check-for-updates";
     public static final String LOG_LEVEL = "log-level";
     public static final String PLUGIN_SUPPORT_CARBONCHAT = "plugin-support.carbonchat";
+    // Discord integration settings
+    public static final String DISCORD_INTEGRATION_ENABLED = "discord-integration.enabled";
+    public static final String DISCORD_INTEGRATION_WEBHOOK_URL = "discord-integration.webhook-url";
+    // Advertising filter settings
+    public static final String CHATGUARD_BLOCK_EXTERNAL_SERVER_ADS = "chatguard-rules.blockExternalServerAds";
+    public static final String CHATGUARD_ALLOWED_SERVER_DOMAINS = "chatguard-rules.allowedServerDomains";
     // Module settings
     public static final String MODULE_CHATGUARD = "modules.chatguard";
     public static final String MODULE_CHAT_CODES = "modules.chat-codes";

--- a/src/main/java/de/pixelmindmc/pixelchat/integration/CarbonChatIntegration.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/integration/CarbonChatIntegration.java
@@ -82,7 +82,7 @@ public class CarbonChatIntegration {
         }
 
         // Check if classification matches any enabled blocking rules
-        if (ChatGuardHelper.messageMatchesEnabledRule(plugin, classification)) {
+        if (ChatGuardHelper.messageMatchesEnabledRule(plugin, message, classification)) {
             boolean blockOrCensor = plugin.getConfigHelper().getString(ConfigConstants.CHATGUARD_MESSAGE_HANDLING).equals("BLOCK");
             if (blockOrCensor) event.cancelled(true);
             else event.message(Component.text("*".repeat(message.length())));

--- a/src/main/java/de/pixelmindmc/pixelchat/integration/DiscordWebhook.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/integration/DiscordWebhook.java
@@ -1,0 +1,55 @@
+package de.pixelmindmc.pixelchat.integration;
+
+import de.pixelmindmc.pixelchat.PixelChat;
+import de.pixelmindmc.pixelchat.constants.ConfigConstants;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Simple helper for sending messages to a Discord webhook
+ */
+public class DiscordWebhook {
+    private final PixelChat plugin;
+    private final String webhookUrl;
+
+    public DiscordWebhook(@NotNull PixelChat plugin) {
+        this.plugin = plugin;
+        this.webhookUrl = plugin.getConfigHelper().getString(ConfigConstants.DISCORD_INTEGRATION_WEBHOOK_URL);
+    }
+
+    /**
+     * Sends a formatted message to the configured Discord webhook
+     *
+     * @param content the message to send
+     */
+    public void sendMessage(@NotNull String content) {
+        if (!plugin.getConfigHelper().getBoolean(ConfigConstants.DISCORD_INTEGRATION_ENABLED)) return;
+        if (webhookUrl == null || webhookUrl.equalsIgnoreCase("WEBHOOK_URL")) return;
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                URL url = new URI(webhookUrl).toURL();
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                connection.setRequestMethod("POST");
+                connection.setRequestProperty("Content-Type", "application/json");
+                connection.setDoOutput(true);
+
+                String payload = "{\"content\":\"" + content.replace("\"", "\\\"") + "\"}";
+                try (OutputStream os = connection.getOutputStream()) {
+                    os.write(payload.getBytes(StandardCharsets.UTF_8));
+                }
+
+                int code = connection.getResponseCode();
+                if (code < 200 || code >= 300) {
+                    plugin.getLoggingHelper().warning("Discord webhook responded with HTTP " + code);
+                }
+            } catch (Exception e) {
+                plugin.getLoggingHelper().warning("Failed to send Discord webhook: " + e.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/de/pixelmindmc/pixelchat/listener/AsyncPlayerChatListener.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/listener/AsyncPlayerChatListener.java
@@ -144,7 +144,7 @@ public class AsyncPlayerChatListener implements Listener {
         }
 
         // Check if classification matches any enabled blocking rules
-        if (ChatGuardHelper.messageMatchesEnabledRule(plugin, classification)) {
+        if (ChatGuardHelper.messageMatchesEnabledRule(plugin, message, classification)) {
             boolean blockOrCensor = plugin.getConfigHelper().getString(ConfigConstants.CHATGUARD_MESSAGE_HANDLING).equals("BLOCK");
             if (blockOrCensor) {
                 event.setCancelled(true);

--- a/src/main/java/de/pixelmindmc/pixelchat/utils/ChatGuardHelper.java
+++ b/src/main/java/de/pixelmindmc/pixelchat/utils/ChatGuardHelper.java
@@ -9,6 +9,7 @@ import de.pixelmindmc.pixelchat.PixelChat;
 import de.pixelmindmc.pixelchat.constants.ConfigConstants;
 import de.pixelmindmc.pixelchat.constants.LangConstants;
 import de.pixelmindmc.pixelchat.model.MessageClassification;
+import de.pixelmindmc.pixelchat.integration.DiscordWebhook;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -55,6 +56,16 @@ public class ChatGuardHelper {
 
         plugin.getLoggingHelper()
                 .info("Message by " + player.getName() + (blockOrCensor ? " has been blocked: " : " has been censored: ") + userMessage);
+
+        // Send notification to Discord if configured
+        new DiscordWebhook(plugin).sendMessage("Player " + player.getName() + " sent: '" + userMessage.replace("\n", " ") + "' Reason: " + classification.reason());
+
+        String reasonLower = classification.reason().toLowerCase();
+        if (reasonLower.contains("hate speech") || reasonLower.contains("slur") || reasonLower.contains("rassismus")) {
+            executeCommand(plugin, plugin.getConfigHelper().getString(ConfigConstants.CHATGUARD_BAN_COMMAND), player.getName(), classification.reason());
+            new DiscordWebhook(plugin).sendMessage("\u26A0\uFE0F\u26A0\uFE0F\u26A0\uFE0F Player " + player.getName() + " banned for racism: " + classification.reason() + " \u26A0\uFE0F\u26A0\uFE0F\u26A0\uFE0F");
+            return;
+        }
 
         if (!classification.isOffensiveLanguage()) return;
 
@@ -150,13 +161,20 @@ public class ChatGuardHelper {
      * @param classification The classification of the message
      * @return true if message violates an active block rule, false if no active block rules have been violated by the message
      */
-    public static boolean messageMatchesEnabledRule(@NotNull PixelChat plugin, @NotNull MessageClassification classification) {
+    public static boolean messageMatchesEnabledRule(@NotNull PixelChat plugin, @NotNull String message, @NotNull MessageClassification classification) {
         boolean blockOffensiveLanguage = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_RULES_BLOCK_OFFENSIVE_LANGUAGE);
         boolean blockUsernames = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_RULES_BLOCK_USERNAMES);
         boolean blockPasswords = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_RULES_BLOCK_PASSWORDS);
         boolean blockHomeAddresses = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_RULES_BLOCK_HOME_ADDRESSES);
         boolean blockEmailAddresses = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_RULES_BLOCK_EMAIL_ADDRESSES);
         boolean blockWebsites = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_RULES_BLOCK_WEBSITES);
+        boolean blockExternalAds = plugin.getConfigHelper().getBoolean(ConfigConstants.CHATGUARD_BLOCK_EXTERNAL_SERVER_ADS);
+
+        if (blockExternalAds && classification.isWebsite()) {
+            java.util.List<String> allowed = plugin.getConfigHelper().getStringList(ConfigConstants.CHATGUARD_ALLOWED_SERVER_DOMAINS);
+            boolean permitted = allowed.stream().anyMatch(domain -> message.toLowerCase().contains(domain.toLowerCase()));
+            if (!permitted) return true;
+        }
 
         if (blockOffensiveLanguage && classification.isOffensiveLanguage()) return true;
         if (blockUsernames && classification.isUsername()) return true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,13 @@ plugin-support:
   # Enable support for CarbonChat integration. [Default: true]
   carbonchat: true # Tested with version 3.0.0-beta.28
 
+#################### Discord Integration ####################
+discord-integration:
+  # Enable or disable sending notifications to Discord. [Default: false]
+  enabled: false
+  # Webhook URL of the Discord channel.
+  webhook-url: "WEBHOOK_URL"
+
 ###################### Module Settings ######################
 
 # Toggle specific plugin modules on/off.
@@ -107,6 +114,11 @@ chatguard-rules:
   blockEmailAddresses: true
   # Restricts users from sharing website URLs to avoid spreading malicious links or inappropriate content.
   blockWebsites: false
+  # Blocks advertising for external servers except the domains listed below.
+  blockExternalServerAds: true
+  # Domains allowed in chat messages.
+  allowedServerDomains:
+    - "leki-world.de"
 
 # Use the built-in strike system for managing player behavior. [Default: true]
 use-built-in-strike-system: true


### PR DESCRIPTION
## Summary
- implement privacy section in README
- include metrics/update init on startup
- add discord integration & advertisement filter defaults to config
- autoban for racist messages and send warning to Discord
- support allowed server domains list when blocking websites

## Testing
- `./gradlew test` *(fails: Could not resolve org.spigotmc:spigot-api)*

------
https://chatgpt.com/codex/tasks/task_e_6849275ba8488320a7593dee2e8c349b